### PR TITLE
Fix !MCTP_HAVE_FILEIO compile failures

### DIFF
--- a/astlpc.c
+++ b/astlpc.c
@@ -1157,7 +1157,7 @@ struct mctp_binding_astlpc *mctp_astlpc_init_fileio(void)
 struct mctp_binding_astlpc * __attribute__((const))
 	mctp_astlpc_init_fileio(void)
 {
-	astlpc_prerr(astlpc, "Missing support for file IO");
+	mctp_prerr("Missing support for file IO");
 	return NULL;
 }
 

--- a/serial.c
+++ b/serial.c
@@ -305,6 +305,30 @@ void mctp_serial_open_fd(struct mctp_binding_serial *serial, int fd)
 {
 	serial->fd = fd;
 }
+#else
+int mctp_serial_read(struct mctp_binding_serial *serial)
+{
+	mctp_prerr("can't read from serial device: %m");
+	return -1;
+}
+
+int mctp_serial_get_fd(struct mctp_binding_serial *serial)
+{
+	mctp_prerr("can't read from serial device: %m");
+	return -1;
+}
+
+int mctp_serial_open_path(struct mctp_binding_serial *serial,
+		const char *device)
+{
+	mctp_prerr("can't read from serial device: %m");
+	return -1;
+}
+
+void mctp_serial_open_fd(struct mctp_binding_serial *serial, int fd)
+{
+	mctp_prerr("can't read from serial device: %m");
+}
 #endif
 
 void mctp_serial_set_tx_fn(struct mctp_binding_serial *serial,


### PR DESCRIPTION
Syntax errors in the astlpc case and linker issues in the demux daemon.