### PR TITLE
astlpc: Drop err.h include

### DIFF
--- a/astlpc.c
+++ b/astlpc.c
@@ -9,7 +9,6 @@
 #endif
 
 #include <assert.h>
-#include <err.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <stdbool.h>


### PR DESCRIPTION
err.h was needed some time ago when astlpc.c just called warnx() and
errx() directly. It uses a logging wrapper now so this isn't needed
and since it's a BSD header it may not be available.

Signed-off-by: Oliver O'Halloran <oohall@gmail.com>