### PR TITLE
Update .gitignore to keep libmctp.pc.in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ depcomp
 *.in
 install-sh
 *.la
+!libmctp.pc.in
 libtool
 *.lo
 *.log


### PR DESCRIPTION
File libmctp.pc.in should not be ignored as it is mandatory for the build but not generated automatically