### PR TITLE
core: Fix use of wrong 'free' function

### DIFF
--- a/core.c
+++ b/core.c
@@ -389,7 +389,7 @@ void mctp_unregister_bus(struct mctp *mctp, struct mctp_binding *binding)
 	mctp->n_busses = 0;
 	binding->mctp = NULL;
 	binding->bus = NULL;
-	free(mctp->busses);
+	__mctp_free(mctp->busses);
 }
 
 int mctp_bridge_busses(struct mctp *mctp, struct mctp_binding *b1,


### PR DESCRIPTION
This memory was allocated using `__mctp_alloc` but mistakenly being free with plain `free`, causing a potential heap corruption or crash if users define their own malloc hooks.