### PR TITLE
Support libmctp as a zephyr module

### DIFF
--- a/serial.c
+++ b/serial.c
@@ -5,6 +5,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 
 #include "crc-16-ccitt.h"
 
@@ -24,6 +25,10 @@ static const size_t write(int fd, void *buf, size_t len)
 #endif
 
 #define pr_fmt(x) "serial: " x
+
+#ifdef CONFIG_MCTP
+#define typeof __typeof__
+#endif
 
 /*
  * @fn: A function that will copy data from the buffer at src into the dst object
@@ -48,6 +53,7 @@ static const size_t write(int fd, void *buf, size_t len)
 		}                                                              \
 		len ? wrote : 0;                                               \
 	})
+
 
 static ssize_t mctp_serial_write(int fildes, const void *buf, size_t nbyte)
 {

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,23 @@
+# Copyright (c) 2024 Intel Corporation.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+set(MCTP_SRC ${CMAKE_CURRENT_SOURCE_DIR}/..)
+
+zephyr_interface_library_named(mctp)
+target_link_libraries(zephyr_interface INTERFACE mctp)
+target_include_directories(mctp INTERFACE ${MCTP_SRC})
+
+zephyr_library_named(modules_mctp)
+zephyr_library_link_libraries(mctp)
+
+zephyr_library_sources_ifdef(
+	CONFIG_MCTP
+	${MCTP_SRC}/alloc.c 
+	${MCTP_SRC}/crc32.c
+	${MCTP_SRC}/core.c
+	${MCTP_SRC}/log.c
+	${MCTP_SRC}/libmctp.h
+	${MCTP_SRC}/serial.c
+	${MCTP_SRC}/crc-16-ccitt.c
+)

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1,0 +1,7 @@
+# Copyright (c) 2024 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+config MCTP
+	bool "Enable MCTP"
+	help
+	  Build libmctp module during build process.

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,4 @@
+name: libmctp
+build:
+  cmake: zephyr 
+  kconfig: zephyr/Kconfig


### PR DESCRIPTION
Adds the needed changes to support directly using libmctp from Zephyr